### PR TITLE
Fix when image not present in registry during build time

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -39,6 +39,7 @@ jobs:
     name: Combine Rocks and Push Multiarch Manifest
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics, run-tests, scan-images]
+    if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:
-      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}


### PR DESCRIPTION
In some cases, mechanics for skipping not changed Rockcraft files cause build errors, for example when pr was merged even when failing. This PR fixes that issue.

KU-1195