### PR TITLE
Integration: unset `parchWebhookJob` read-only FS in chart.

### DIFF
--- a/tests/integration/test_nginx_components_in_helm_chart.py
+++ b/tests/integration/test_nginx_components_in_helm_chart.py
@@ -139,6 +139,8 @@ def test_nginx_ingress_chart_deployment(
         [
             "--set",
             "controller.admissionWebhooks.createSecretJob.securityContext.readOnlyRootFilesystem=false",
+            "--set",
+            "controller.admissionWebhooks.patchWebhookJob.securityContext.readOnlyRootFilesystem=false",
         ]
     )
 


### PR DESCRIPTION
In the Helm Chart used in the integration tests, the `kube-webhook-certgen` image is run a second time to patch certs in the secret created by the first run of the image, and it also requires its root filesystem to not be read-only in order for Pebble to properly create its state files.