### PR TITLE
integration: work around controller perms/caps issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,26 @@ Images are meant to be drop-in replacements for the following upstream images:
 
 * registry.k8s.io/ingress-nginx/controller
 * registry.k8s.io/ingress-nginx/kube-webhook-certgen
+
+:warning: the current version of the `controller` ROCKs must be run as `root`,
+both because the ROCKs must `ldconfig` some dynamic libs on startup (which is
+automatically handled by an entrypoint script), as well as `rockcraft` not
+currently being able to preserve file capabilities via extended attributes
+(see https://github.com/canonical/rockcraft/issues/683).
+
+In order to use it with the upstream Helm chart or similar setups, please ensure
+you set the proper securityContext settings as follows:
+
+```bash
+helm install ingress-nginx \
+    # Relevant individual settings:
+    --set controller.image.runAsUser=0 \
+    --set controller.image.runAsGroup=0 \
+    --set controller.image.runAsNonRoot=false \
+    --set controller.image.readOnlyRootFilesystem=false \
+    # Required by the `kube-webhook-certgen` rock, as Pebble writes to '/var/lib/pebble':
+    --set controller.admissionWebhooks.createSecretJob.securityContext.readOnlyRootFilesystem=false \
+    --set controller.admissionWebhooks.patchWebhookJob.securityContext.readOnlyRootFilesystem=false \
+    # Required security context for controller. Of special note is `capabilities: null`:
+    --set-json controller.containerSecurityContext='{"runAsNonRoot":false,"runAsUser":0,"runAsGroup":0,"allowPrivilegeEscalation":false,"capabilities":null,"readOnlyRootFilesystem":false}'
+```

--- a/controller/README.md
+++ b/controller/README.md
@@ -1,3 +1,26 @@
 # ROCK specs for Nginx ingress `controller`.
 
-Aims to be compatible with `registry.k8s.io/ingress-nginx/controller:v1.11.0`.
+Aims to be compatible with the `registry.k8s.io/ingress-nginx/controller:vX.Y.Z` images.
+
+:warning: the current version of the `controller` ROCKs must be run as `root`,
+both because the ROCKs must `ldconfig` some dynamic libs on startup (which is
+automatically handled by an entrypoint script), as well as `rockcraft` not
+currently being able to preserve file capabilities via extended attributes
+(see https://github.com/canonical/rockcraft/issues/683).
+
+In order to use it with the upstream Helm chart or similar setups, please ensure
+you set the proper securityContext settings as follows:
+
+```bash
+helm install ingress-nginx \
+    # Relevant individual settings:
+    --set controller.image.runAsUser=0 \
+    --set controller.image.runAsGroup=0 \
+    --set controller.image.runAsNonRoot=false \
+    --set controller.image.readOnlyRootFilesystem=false \
+    # Required by the `kube-webhook-certgen` rock, as Pebble writes to '/var/lib/pebble':
+    --set controller.admissionWebhooks.createSecretJob.securityContext.readOnlyRootFilesystem=false \
+    --set controller.admissionWebhooks.patchWebhookJob.securityContext.readOnlyRootFilesystem=false \
+    # Required security context for controller. Of special note is `capabilities: null`:
+    --set-json controller.containerSecurityContext='{"runAsNonRoot":false,"runAsUser":0,"runAsGroup":0,"allowPrivilegeEscalation":false,"capabilities":null,"readOnlyRootFilesystem":false}'
+```

--- a/controller/v1.10.1/pebble-entrypoint.sh
+++ b/controller/v1.10.1/pebble-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# Required to prevent Pebble from considering the service to have
+# exited too quickly to be worth restarting or respecting the
+# "on-failure: shutdown" directive and thus hanging indefinitely:
+# https://github.com/canonical/pebble/issues/240#issuecomment-1599722443
+sleep 1.1
+
+# NOTE(aznashwan): the controller image includes a
+# number of dynamic libs which must be indexed:
+ldconfig
+
+ARGS="$@"
+if [ $# -eq 0 ]; then
+    # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L87
+    ARGS="/nginx-ingress-controller"
+fi
+
+# https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L86
+exec /usr/bin/dumb-init -- $ARGS
+

--- a/controller/v1.10.1/rockcraft.yaml
+++ b/controller/v1.10.1/rockcraft.yaml
@@ -26,7 +26,10 @@ services:
     startup: enabled
     override: replace
 
-    command: /usr/bin/dumb-init -- [ /nginx-ingress-controller ]
+    command: /pebble-entrypoint.sh [ /nginx-ingress-controller ]
+
+    # on-success: shutdown
+    # on-failure: shutdown
 
 entrypoint-service: nginx
 
@@ -63,7 +66,6 @@ parts:
       - libmaxminddb-dev
       - libyaml-cpp-dev
       - libprotobuf-dev
-      - dumb-init
       - tzdata
 
     overlay-script: |
@@ -773,6 +775,7 @@ parts:
         /opt/modsecurity/var/audit \
         /var/log/audit \
         /var/log/nginx \
+        /var/www \
         /tmp/nginx \
       );
 
@@ -793,6 +796,9 @@ parts:
       # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L73-L74
       setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/local/nginx/sbin/nginx
       setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/local/nginx/sbin/nginx
+      # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L78
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      ln -s /usr/local/nginx/sbin/nginx $CRAFT_PART_INSTALL/usr/bin/nginx
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
       LIBPATH="/usr/lib/x86_64-linux-gnu"
@@ -805,25 +811,34 @@ parts:
       cp -rp /opt/* $CRAFT_PART_INSTALL/opt
 
       # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L42
-      mkdir -p $CRAFT_PART_INSTALL/etc/nginx
+      mkdir -p $CRAFT_PART_INSTALL/etc
+      cp -rp /etc/nginx $CRAFT_PART_INSTALL/etc/nginx
       cp -rp $CRAFT_PART_SRC/rootfs/etc/nginx/* $CRAFT_PART_INSTALL/etc/nginx
-      cp -rp /etc/nginx/* $CRAFT_PART_INSTALL/etc/nginx
+      cp -rp /etc/ingress-controller $CRAFT_PART_INSTALL/etc/ingress-controller
 
       # Added files/directories that need creating:
       mkdir -p $CRAFT_PART_INSTALL/var/log
       cp -rp /var/log/nginx $CRAFT_PART_INSTALL/var/log
       cp -rp /var/log/audit $CRAFT_PART_INSTALL/var/log
 
+      cp -rp /var/www $CRAFT_PART_INSTALL/var
       mkdir -p $CRAFT_PART_INSTALL/var/lib/nginx
 
+      mkdir -p $CRAFT_PART_INSTALL/tmp
+      cp -rp /tmp/nginx $CRAFT_PART_INSTALL/tmp
+
     stage:
+      - usr/bin/*
       - usr/local/*
       - usr/lib/*
       - opt/*
       - etc/nginx/*
+      - etc/ingress-controller/*
+      - tmp/nginx
       - var/log/nginx
       - var/log/audit
       - var/lib/nginx
+      - var/www
 
   build-go-binaries:
     after: ['build-nginx']
@@ -838,6 +853,7 @@ parts:
 
     build-packages:
       - libcap2-bin
+      - dumb-init
 
     source-type: git
     source: https://github.com/kubernetes/ingress-nginx
@@ -866,6 +882,13 @@ parts:
       setcap cap_net_bind_service=+ep $CRAFT_PART_INSTALL/nginx-ingress-controller
       setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/nginx-ingress-controller
 
-      # NOTE(aznashwan): dumb-init is a staged package.
-      # setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
-      # setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+      # NOTE(aznashwan): need to set proper caps on dumb-init:
+      # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L75-L76
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      cp /usr/bin/dumb-init $CRAFT_PART_INSTALL/usr/bin
+      setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+      setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+
+      cp $CRAFT_PROJECT_DIR/pebble-entrypoint.sh $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+

--- a/controller/v1.10.1/rockcraft.yaml
+++ b/controller/v1.10.1/rockcraft.yaml
@@ -28,8 +28,8 @@ services:
 
     command: /pebble-entrypoint.sh [ /nginx-ingress-controller ]
 
-    # on-success: shutdown
-    # on-failure: shutdown
+    on-success: shutdown
+    on-failure: shutdown
 
 entrypoint-service: nginx
 

--- a/controller/v1.11.0/pebble-entrypoint.sh
+++ b/controller/v1.11.0/pebble-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# Required to prevent Pebble from considering the service to have
+# exited too quickly to be worth restarting or respecting the
+# "on-failure: shutdown" directive and thus hanging indefinitely:
+# https://github.com/canonical/pebble/issues/240#issuecomment-1599722443
+sleep 1.1
+
+# NOTE(aznashwan): the controller image includes a
+# number of dynamic libs which must be indexed:
+ldconfig
+
+ARGS="$@"
+if [ $# -eq 0 ]; then
+    # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.11.0/rootfs/Dockerfile#L87
+    ARGS="/nginx-ingress-controller"
+fi
+
+# https://github.com/kubernetes/ingress-nginx/blob/controller-v1.11.0/rootfs/Dockerfile#L86
+exec /usr/bin/dumb-init -- $ARGS
+

--- a/controller/v1.11.0/rockcraft.yaml
+++ b/controller/v1.11.0/rockcraft.yaml
@@ -26,7 +26,12 @@ services:
     startup: enabled
     override: replace
 
-    command: /usr/bin/dumb-init -- [ /nginx-ingress-controller ]
+    # NOTE(aznashwan): the entrypoint script simply runs
+    # 'ldconfig' before exec-ing the controller binary:
+    command: /pebble-entrypoint.sh [ /nginx-ingress-controller ]
+
+    # on-success: shutdown
+    # on-failure: shutdown
 
 entrypoint-service: nginx
 
@@ -63,7 +68,6 @@ parts:
       - libmaxminddb-dev
       - libyaml-cpp-dev
       - libprotobuf-dev
-      - dumb-init
       - tzdata
 
     overlay-script: |
@@ -773,6 +777,7 @@ parts:
         /opt/modsecurity/var/audit \
         /var/log/audit \
         /var/log/nginx \
+        /var/www \
         /tmp/nginx \
       );
       for dir in "${writeDirs[@]}"; do
@@ -792,6 +797,9 @@ parts:
       # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.11.0/rootfs/Dockerfile#L73-L74
       setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/local/nginx/sbin/nginx
       setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/local/nginx/sbin/nginx
+      # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile#L78
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      ln -s /usr/local/nginx/sbin/nginx $CRAFT_PART_INSTALL/usr/bin/nginx
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
       LIBPATH="/usr/lib/x86_64-linux-gnu"
@@ -802,25 +810,34 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/opt
       cp -rp /opt/* $CRAFT_PART_INSTALL/opt
 
-      mkdir -p $CRAFT_PART_INSTALL/etc/nginx
+      mkdir -p $CRAFT_PART_INSTALL/etc
+      cp -rp /etc/nginx $CRAFT_PART_INSTALL/etc/nginx
       cp -rp $CRAFT_PART_SRC/rootfs/etc/nginx/* $CRAFT_PART_INSTALL/etc/nginx
-      cp -rp /etc/nginx/* $CRAFT_PART_INSTALL/etc/nginx
+      cp -rp /etc/ingress-controller $CRAFT_PART_INSTALL/etc/ingress-controller
 
       # Added files/directories that need creating:
       mkdir -p $CRAFT_PART_INSTALL/var/log
       cp -rp /var/log/nginx $CRAFT_PART_INSTALL/var/log
       cp -rp /var/log/audit $CRAFT_PART_INSTALL/var/log
 
+      cp -rp /var/www $CRAFT_PART_INSTALL/var
       mkdir -p $CRAFT_PART_INSTALL/var/lib/nginx
 
+      mkdir -p $CRAFT_PART_INSTALL/tmp
+      cp -rp /tmp/nginx $CRAFT_PART_INSTALL/tmp
+
     stage:
+      - usr/bin/*
       - usr/local/*
       - usr/lib/*
       - opt/*
       - etc/nginx/*
+      - etc/ingress-controller/*
+      - tmp/nginx
       - var/log/nginx
       - var/log/audit
       - var/lib/nginx
+      - var/www
 
   build-go-binaries:
     after: ['build-nginx']
@@ -835,6 +852,7 @@ parts:
 
     build-packages:
       - libcap2-bin
+      - dumb-init
 
     source-type: git
     source: https://github.com/kubernetes/ingress-nginx
@@ -863,6 +881,13 @@ parts:
       setcap cap_net_bind_service=+ep $CRAFT_PART_INSTALL/nginx-ingress-controller
       setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/nginx-ingress-controller
 
-      # NOTE(aznashwan): dumb-init is a staged package.
-      # setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
-      # setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+      # NOTE(aznashwan): need to set proper caps on dumb-init:
+      # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.11.0/rootfs/Dockerfile#L75-L76
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      cp /usr/bin/dumb-init $CRAFT_PART_INSTALL/usr/bin
+      setcap    cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+      setcap -v cap_net_bind_service=+ep $CRAFT_PART_INSTALL/usr/bin/dumb-init
+
+      cp $CRAFT_PROJECT_DIR/pebble-entrypoint.sh $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+

--- a/controller/v1.11.0/rockcraft.yaml
+++ b/controller/v1.11.0/rockcraft.yaml
@@ -30,8 +30,8 @@ services:
     # 'ldconfig' before exec-ing the controller binary:
     command: /pebble-entrypoint.sh [ /nginx-ingress-controller ]
 
-    # on-success: shutdown
-    # on-failure: shutdown
+    on-success: shutdown
+    on-failure: shutdown
 
 entrypoint-service: nginx
 

--- a/tests/integration/test_nginx_components_in_helm_chart.py
+++ b/tests/integration/test_nginx_components_in_helm_chart.py
@@ -139,6 +139,8 @@ def test_nginx_ingress_chart_deployment(
         [
             "--set",
             "controller.admissionWebhooks.createSecretJob.securityContext.readOnlyRootFilesystem=false",
+            "--set",
+            "controller.admissionWebhooks.patchWebhookJob.securityContext.readOnlyRootFilesystem=false",
         ]
     )
 


### PR DESCRIPTION
This patch includes adaptations to the controller rockcraft specs
and integrations tests necessary to work around permissions/capabilities
issues which prevented the controller to be run as a non-root user.

Notable changes include:
* the addition of a `/pebble-entrypoint.sh` script which runs `ldconfig`
  prior to exec-ing the actual entrypoint of the ROCK.
* overriding the securityContext of the controller containers in the
  Helm chart used for integration testing.
* pre-creation of some empty directories which are normally
  externally-mounted.

Signed-off-by: Nashwan Azhari <nashwan.azhari@canonical.com>